### PR TITLE
A 'fix' for edit two edit input components

### DIFF
--- a/src/components/edit/inputs/object-select/object-select-input.tsx
+++ b/src/components/edit/inputs/object-select/object-select-input.tsx
@@ -1,9 +1,11 @@
 import { Box } from "@mui/material";
 import { SelectInput, SelectInputProps } from "../select/select-input";
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useContext, useEffect, useState } from "react";
 import { useWatch, useFormContext } from "react-hook-form";
 import { UnknownObject } from "@/src/components/content-display/data-visualization/d3/types";
 import { inputMap } from "../input.map";
+import { PageStateContext } from "../../page/context/state/page-state.context";
+import { getParentId } from "@/src/utils/edit";
 
 type OptionsMapProps = {
 	optionsMap: Map<string, UnknownObject[]>;
@@ -11,6 +13,13 @@ type OptionsMapProps = {
 };
 
 type ObjectSelectInput = PropsWithChildren<SelectInputProps & OptionsMapProps>;
+
+const createNewId = (id: string, optionId: string) => {
+	const parentId = getParentId(id);
+	// if given option id - create object
+	// else add to main object/parent
+	return optionId ? `${parentId}.${optionId}` : parentId;
+};
 
 const renderChildren = (
 	inputs: UnknownObject[] | undefined,
@@ -20,14 +29,9 @@ const renderChildren = (
 	if (!inputs) {
 		return []; // null;
 	}
-	const idAsArray = id.split(".");
-	const newIdAsArray = idAsArray.splice(0, idAsArray.length - 1);
-	// if given option id - create object
-	// else add to main object/parent
-	const newId = optionId
-		? `${newIdAsArray.join(".")}.${optionId}`
-		: `${newIdAsArray.join(".")}`;
+	const newId = createNewId(id, optionId);
 
+	// InputList?
 	// filter rather than map
 	return inputs.map((input) => {
 		const { id: inputId, info, label, type, ...rest } = input;
@@ -62,12 +66,51 @@ export const ObjectSelectInput = ({
 }: ObjectSelectInput) => {
 	const [components, setComponents] = useState<(JSX.Element | null)[]>([]);
 	const { setValue } = useFormContext();
+	const { getValue: getPageData } = useContext(PageStateContext);
 	const value: string = useWatch({
 		name: id,
 	});
 
+	console.log("1001:EDIT", { value, id });
+
+	////////////////////////
+	// Hack / Force update
+	// If no data exists / try to get the data
+	// Works for optionId using option selects
+	// Non optionId - might work without further change
+	// Needs further testing
+	// As a rough fix - fine - as a guide for more - fine
+	// Ultimately - we need to redo edit and probably follow this type of approach
+	//////////////////////////////
+	useEffect(() => {
+		if (!value) {
+			// This is really a hack
+			const val = getPageData(id);
+			if (!val) return;
+
+			setValue(id, val);
+
+			const newId = createNewId(id, optionId);
+
+			if (optionId) {
+				const optionData = getPageData(newId);
+				if (!optionData) return;
+
+				setValue(newId, optionData);
+				return;
+			}
+
+			// This may work without further change - we need to test
+			// we also need to get and set values for each sub element / optionId
+			// populateOptions();
+
+			console.log("1001:GOT:VALUE", { id, val });
+		}
+	}, [getPageData, id, optionId, setValue, value]);
+
 	useEffect(() => {
 		if (value) {
+			console.log("1001:EDIT setValue", { value });
 			setValue(id, value);
 			setComponents(renderChildren(optionsMap.get(value), id, optionId));
 		}

--- a/src/components/edit/page/context/query/page-query.context.tsx
+++ b/src/components/edit/page/context/query/page-query.context.tsx
@@ -36,6 +36,7 @@ export const PageQueryProvider = ({
 	value?: PageQueryState;
 	children: ReactNode;
 }) => {
+	// type me
 	const [pageData, setPageData] = useState({});
 
 	const { currentPage } = useContext(EditContext);

--- a/src/components/edit/page/context/state/page-state.context.tsx
+++ b/src/components/edit/page/context/state/page-state.context.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext, useContext, useEffect } from "react";
 import { PageQueryContext } from "../query/page-query.context";
 import { useFormContext } from "react-hook-form";
 import { EditContext } from "@/src/context/edit-context";
+import { getNestedValue } from "@/src/utils/object";
 
 /////////////////////////////////////////////////////////////
 // What is setting the rest - this seems off
@@ -37,6 +38,7 @@ type PageStateInterface = {
 	pageContainerId: string;
 	pagePropsId: string;
 	pageComponentsId: string;
+	getValue: (id: string) => any;
 };
 
 const initialState: PageStateState & PageStateInterface = {
@@ -47,6 +49,7 @@ const initialState: PageStateState & PageStateInterface = {
 	pageContainerId: `${FORM_ID}.${CONTAINER_ID}`,
 	pagePropsId: `${FORM_ID}.${PROPS_ID}`,
 	pageComponentsId: `${FORM_ID}.${COMPONENTS_ID}`,
+	getValue(id) {},
 };
 
 // BUG, ISSUE, !!!
@@ -61,6 +64,15 @@ export const PageStateContextProvider = ({
 	const { currentPage } = useContext(EditContext);
 	const { setValue, unregister } = useFormContext();
 	const { pageData } = useContext(PageQueryContext);
+
+	// We probably want a dedicated context or store for this?
+	// This is our source of truth / the data we have loaded
+	// We 'should' be reading this for start data
+	const getValue = (id: string) => {
+		const { page } = pageData;
+		const ret = getNestedValue(`${id}`, page);
+		return ret;
+	};
 
 	// Sort out edit state
 	// Seperating seems to have fixed our issue
@@ -117,6 +129,7 @@ export const PageStateContextProvider = ({
 				pageComponentsId,
 				pageContainerId,
 				pagePropsId,
+				getValue,
 			}}
 		>
 			{children}

--- a/src/queries/pages/get-page-queries.ts
+++ b/src/queries/pages/get-page-queries.ts
@@ -1,3 +1,5 @@
+// TYPE ME !!!!
+
 export async function getPageById(id: string): Promise<any> {
 	const response = await fetch(`/api/page/${id}`);
 	return await response.json();

--- a/src/utils/edit/index.ts
+++ b/src/utils/edit/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @param id - edit object id path - diliminated by '.'
+ * @returns - The parent object path of the given object id
+ */
+export const getParentId = (id: string) => {
+	const idAsArray = id.split(".");
+	const newIdAsArray = idAsArray.splice(0, idAsArray.length - 1);
+	return newIdAsArray.join(".");
+};

--- a/src/utils/object/index.ts
+++ b/src/utils/object/index.ts
@@ -93,6 +93,7 @@ export const filterObjectByKeys = (obj: UnknownObject, values: string[]) => {
  * @param obj - The object
  * @returns Object key value
  ****
+ * @WARNING returns whole or partial object rather than null if no object key found / UPDATE return null
  */
 export const getNestedValue = <T>(
 	key: string,
@@ -105,7 +106,8 @@ export const getNestedValue = <T>(
 	let value = object;
 	const len = nestedKeys.length;
 	for (let i = 0; i < len; i++) {
-		value = value[nestedKeys[i]] || value;
+		value = value[nestedKeys[i]];
+		if (!value) return null;
 	}
 	// This is a bit hacky
 	// return could be given object


### PR DESCRIPTION
If undefined (select & input list) check loaded data and reassign The bigger issue is the inputs are re-rendered and reset